### PR TITLE
Fix page loading by updating server configuration and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 package-lock.json
 playwright-report/
 test-results/
+dist/

--- a/README.md
+++ b/README.md
@@ -32,8 +32,24 @@ A web-based application to explore various 3D rendered sites in Western Australi
 
 ### Running the Project
 
-- Open the `index.html` file in a web browser.
-- For development, a local web server (e.g., Live Server extension in VS Code, or `python -m http.server`) might be necessary for some features like loading local files (models, textures) due to browser security restrictions (CORS).
+To run the project locally, you must use a development server that supports ES modules and bare imports (via Vite).
+
+1.  Start the development server:
+    ```bash
+    npm run dev
+    ```
+2.  Open the URL shown in the terminal (usually `http://localhost:5173`).
+
+To build and preview the production version:
+
+1.  Build the project:
+    ```bash
+    npm run build
+    ```
+2.  Preview the build:
+    ```bash
+    npm run preview
+    ```
 
 ## Usage Examples
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,7 +33,7 @@ module.exports = defineConfig({
         },
     ],
     webServer: {
-        command: 'python3 -m http.server 8080',
+        command: 'npm run build && npm run preview -- --port 8080',
         port: 8080,
         reuseExistingServer: !process.env.CI,
     },


### PR DESCRIPTION
The application was failing to load when using simple static servers (like `python -m http.server`) because it relies on ES module bare imports which require a bundler or import map. The README and Playwright configuration were updated to use `npm run dev` and `npm run preview` respectively. Also added `dist/` to `.gitignore` to prevent committing build artifacts.

---
*PR created automatically by Jules for task [16454178704832902724](https://jules.google.com/task/16454178704832902724) started by @rajeshceg3*